### PR TITLE
Fix casing for category values

### DIFF
--- a/src/app/data/category-data.ts
+++ b/src/app/data/category-data.ts
@@ -139,7 +139,7 @@ export const legumes: CategoryItem[] = [
 export const Meat: CategoryItem[] = [
   { value: 'chicken', viewValue: 'Chicken' },
   { value: 'beef', viewValue: 'Beef' },
-  { value: 'Vegetarian', viewValue: 'Vegetarian' },
+  { value: 'vegetarian', viewValue: 'Vegetarian' },
   { value: 'pork', viewValue: 'Pork' },
   { value: 'lamb', viewValue: 'Lamb' },
   { value: 'turkey', viewValue: 'Turkey' },
@@ -156,7 +156,7 @@ export const Dairy: CategoryItem[] = [
   { value: 'cheese', viewValue: 'Cheese' },
   { value: 'yogurt', viewValue: 'Yogurt' },
   { value: 'butter', viewValue: 'Butter' },
-  { value: 'Eggs', viewValue: 'Eggs' },
+  { value: 'eggs', viewValue: 'Eggs' },
   { value: 'cream', viewValue: 'Cream' },
   { value: 'ghee', viewValue: 'Ghee' },
   { value: 'paneer', viewValue: 'Paneer' },


### PR DESCRIPTION
## Summary
- ensure the Dairy category uses lowercase key for eggs
- lowercase the vegetarian key for consistency in Meat list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840716ef1b08326bee21a04fa8c621f